### PR TITLE
Disabled delimiter parsing in save methods

### DIFF
--- a/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
@@ -161,6 +161,7 @@ public class SimpleConfiguration {
 
   public void save(File file) {
     PropertiesConfiguration pconf = new PropertiesConfiguration();
+    pconf.setDelimiterParsingDisabled(true);
     pconf.append(internalConfig);
     try {
       pconf.save(file);
@@ -172,6 +173,7 @@ public class SimpleConfiguration {
 
   public void save(OutputStream out) {
     PropertiesConfiguration pconf = new PropertiesConfiguration();
+    pconf.setDelimiterParsingDisabled(true);
     pconf.append(internalConfig);
     try {
       pconf.save(out);


### PR DESCRIPTION
* Fixes bug that was causing comma to be prepended with slash when
observer config was was saved.
* Bug found when using phrasecount application