### PR TITLE
Avoid guava beta dependency and updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ news and general information.
 There are several ways to run Fluo (listed in order of increasing difficulty):
 
 * [quickstart] - Starts a MiniFluo instance that is configured to run a word count application
-* [fluo-dev] - Command-line tool for running Fluo and its dependencies on a single machine
-* [Zetten] - Command-line tool that launches an AWS cluster and sets up Fluo/Accumulo on it
-* [Production] - Sets up Fluo on a cluster where Accumulo, Hadoop & Zookeeper are running
+* [fluo-dev] - Automated tool that sets up Fluo and its dependencies on a single machine
+* [Zetten] - Automated tool that launches an AWS cluster and sets up Fluo/Accumulo on it
+* [Install instructions][install] - Manually set up Fluo on a cluster where Accumulo, Hadoop & Zookeeper are running
 
 Except for [quickstart], all above will set up a Fluo application that will be idle unless you
 create client & observer code for your application. You can either [create your own
@@ -50,7 +50,7 @@ Below are helpful resources for Fluo application developers:
 [phrasecount]: https://github.com/fluo-io/phrasecount
 [fluo-stress]: https://github.com/fluo-io/fluo-stress
 [webindex]: https://github.com/fluo-io/webindex
-[Production]: docs/prod-fluo-setup.md
+[install]: docs/install.md
 [apps]: docs/applications.md
 [api]: https://fluo.apache.org/apidocs/
 [recipes]: https://github.com/apache/incubator-fluo-recipes

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,20 +1,22 @@
-Production Setup
-================
+Fluo Install Instructions
+=========================
 
-Below are instructions for running Fluo in a production environment where Accumulo,
-Hadoop & Zookeeper are installed and running.  If you want to avoid setting up
-these dependencies, consider using [fluo-dev]. 
+Install instructions for running Fluo on machine or cluster where Accumulo, Hadoop,
+and Zookeeper are installed and running.  If you want to avoid setting up these
+dependencies, consider using [fluo-dev] or [Zetten].
 
 Requirements
 ------------
 
-Before you install Fluo, you will need the following installed and running on
+Before you install Fluo, the following software must be installed and running on
 your local machine or cluster:
 
-* [Accumulo][Accumulo] (version 1.6+)
-* [Hadoop][Hadoop] (version 2.6+)
-* [Zookeeper]
-* [Java][Java] (version 8+)
+| Software    | Recommended Version | Minimum Version |
+|-------------|---------------------|-----------------|
+| [Accumulo]  | 1.7.2               | 1.6.1           |
+| [Hadoop]    | 2.7.2               | 2.6.0           |
+| [Zookeeper] | 3.4.8               |                 |
+| [Java]      | JDK 8               | JDK 8           |
 
 Obtain a distribution
 ---------------------
@@ -51,8 +53,9 @@ application settings (like observers).
 to use a value different than the default.  Properties that are unset and uncommented must be
 set by the user.
 
-4. Fluo needs build its classpath using jars from the version of Hadoop, Accumulo, and Zookeeper
-that you are using. Choose one of the two ways below to make these jars available to Fluo:
+4. Fluo needs to build its classpath using jars from the versions of Hadoop, Accumulo, and
+Zookeeper that you are using. Choose one of the two ways below to make these jars available
+to Fluo:
 
     * Set `HADOOP_PREFIX`, `ACCUMULO_HOME`, and `ZOOKEEPER_HOME` in your environment or configure
     these variables in [fluo-env.sh].  Fluo will look in these locations for jars.
@@ -61,7 +64,7 @@ that you are using. Choose one of the two ways below to make these jars availabl
     default versions set in [lib/ahz/pom.xml]. If you are not using the default versions, you can
     override them:
     
-            ./lib/fetch.sh ahz -Daccumulo.version=1.7.1 -Dhadoop.version=2.6.3 -Dzookeeper.version=3.4.8
+            ./lib/fetch.sh ahz -Daccumulo.version=1.7.2 -Dhadoop.version=2.7.2 -Dzookeeper.version=3.4.8
 
 5. Fluo needs more dependencies than what is available from Hadoop, Accumulo, and Zookeeper.
 These extra dependencies need to be downloaded to `lib/` using the command below:
@@ -212,6 +215,7 @@ In a distributed environment, you will need to deploy and configure a Fluo
 distribution on every node in your cluster.
 
 [fluo-dev]: https://github.com/fluo-io/fluo-dev
+[Zetten]: https://github.com/fluo-io/zetten
 [Accumulo]: https://accumulo.apache.org/
 [Hadoop]: http://hadoop.apache.org/
 [Zookeeper]: http://zookeeper.apache.org/

--- a/modules/core/src/main/java/org/apache/fluo/core/oracle/FluoOracleImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/oracle/FluoOracleImpl.java
@@ -19,8 +19,6 @@ import java.io.File;
 import java.util.Objects;
 
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.AbstractIdleService;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.curator.framework.recipes.cache.NodeCache;
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.exceptions.FluoException;
@@ -36,55 +34,28 @@ public class FluoOracleImpl implements FluoOracle {
 
   private static final Logger log = LoggerFactory.getLogger(FluoOracleImpl.class);
 
-  private OracleService oracleService;
+  private FluoConfiguration config;
+  private Environment env;
+  private AutoCloseable reporters;
+  private OracleServer oracleServer;
+  private NodeCache appIdCache;
 
   public FluoOracleImpl(FluoConfiguration config) {
-    this.oracleService = new OracleService(config);
+    Objects.requireNonNull(config);
+    Preconditions.checkArgument(config.hasRequiredOracleProps());
+    // any client in oracle should retry forever
+    config.setClientRetryTimeout(-1);
+    try {
+      config.validate();
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid FluoConfiguration", e);
+    }
+    this.config = config;
   }
 
   @Override
   public void start() {
     try {
-      oracleService.startAndWait();
-    } catch (UncheckedExecutionException e) {
-      throw new FluoException(e);
-    }
-  }
-
-  @Override
-  public void stop() {
-    try {
-      oracleService.stopAndWait();
-    } catch (UncheckedExecutionException e) {
-      throw new FluoException(e);
-    }
-  }
-
-  private static class OracleService extends AbstractIdleService {
-
-    private static final Logger log = LoggerFactory.getLogger(OracleService.class);
-
-    private FluoConfiguration config;
-    private Environment env;
-    private AutoCloseable reporters;
-    private OracleServer oracleServer;
-    private NodeCache appIdCache;
-
-    OracleService(FluoConfiguration config) {
-      Objects.requireNonNull(config);
-      Preconditions.checkArgument(config.hasRequiredOracleProps());
-      // any client in oracle should retry forever
-      config.setClientRetryTimeout(-1);
-      try {
-        config.validate();
-      } catch (Exception e) {
-        throw new IllegalArgumentException("Invalid FluoConfiguration", e);
-      }
-      this.config = config;
-    }
-
-    @Override
-    protected void startUp() throws Exception {
       env = new Environment(config);
       reporters = ReporterUtil.setupReporters(env);
       appIdCache = CuratorUtil.startAppIdWatcher(env);
@@ -95,14 +66,20 @@ public class FluoOracleImpl implements FluoOracle {
 
       oracleServer = new OracleServer(env);
       oracleServer.start();
+    } catch (Exception e) {
+      throw new FluoException(e);
     }
+  }
 
-    @Override
-    protected void shutDown() throws Exception {
+  @Override
+  public void stop() {
+    try {
       oracleServer.stop();
       appIdCache.close();
       reporters.close();
       env.close();
+    } catch (Exception e) {
+      throw new FluoException(e);
     }
   }
 

--- a/modules/distribution/src/main/lib/ahz/pom.xml
+++ b/modules/distribution/src/main/lib/ahz/pom.xml
@@ -20,8 +20,8 @@
   <version>a</version>
 
   <properties>
-    <accumulo.version>1.7.1</accumulo.version>
-    <hadoop.version>2.6.3</hadoop.version>
+    <accumulo.version>1.7.2</accumulo.version>
+    <hadoop.version>2.7.2</hadoop.version>
     <zookeeper.version>3.4.8</zookeeper.version>
   </properties>
 

--- a/modules/distribution/src/main/lib/fetch.sh
+++ b/modules/distribution/src/main/lib/fetch.sh
@@ -108,6 +108,6 @@ extra)
   echo -e "   extra     Download extra Fluo dependencies\n"
   echo "For 'ahz', the versions of Hadoop, Accumulo, & Zookeeper are specifed in ahz/pom.xml."
   echo -e "However, you can override them using the command below:\n"
-  echo "./fetch.sh ahz -Daccumulo.version=1.7.1 -Dhadoop.version=2.6.3 -Dzookeeper.version=3.4.8"
+  echo "./fetch.sh ahz -Daccumulo.version=1.7.2 -Dhadoop.version=2.7.2 -Dzookeeper.version=3.4.8"
 esac
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <version>1.32</version>
       </dependency>
       <dependency>
+        <!-- Guava 13.0.1 is required by Twill (due to beta method usage) -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>13.0.1</version>


### PR DESCRIPTION
* Update Oracle and worker to avoid using Guava abstract service which is beta
* Update documentation to recommend certain versions of Hadoop, Accumulo, etc
* Renamed prod-fluo-setup.md to install.md