### PR TITLE
Fixes #727 - Avoid console output in tests

### DIFF
--- a/modules/accumulo/src/main/java/org/apache/fluo/accumulo/iterators/TimestampSkippingIterator.java
+++ b/modules/accumulo/src/main/java/org/apache/fluo/accumulo/iterators/TimestampSkippingIterator.java
@@ -140,7 +140,6 @@ public class TimestampSkippingIterator implements SortedKeyValueIterator<Key, Va
       } else if (iter instanceof SortedMapIterator) {
         return null;
       } else {
-        // System.out.println("unknown type " + iter.getClass().getName());
         return null;
       }
     } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>zookeeper</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/NotificationGcIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/NotificationGcIT.java
@@ -34,8 +34,12 @@ import org.apache.fluo.integration.TestTransaction;
 import org.apache.fluo.integration.impl.WeakNotificationIT.SimpleObserver;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NotificationGcIT extends ITBaseMini {
+
+  private static final Logger log = LoggerFactory.getLogger(NotificationGcIT.class);
 
   private static void assertRawNotifications(int expected, Environment env) throws Exception {
     Scanner scanner = env.getConnector().createScanner(env.getTable(), env.getAuthorizations());
@@ -43,7 +47,7 @@ public class NotificationGcIT extends ITBaseMini {
     int size = Iterables.size(scanner);
     if (size != expected) {
       for (Entry<Key, Value> entry : scanner) {
-        System.out.println(entry);
+        log.error(entry.toString());
       }
     }
     Assert.assertEquals(expected, size);

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
@@ -43,6 +43,8 @@ import org.apache.fluo.integration.TestTransaction;
 import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This test starts multiple thread that randomly transfer between accounts. At any given time the
@@ -50,6 +52,7 @@ import org.junit.Test;
  */
 public class StochasticBankIT extends ITBaseImpl {
 
+  private static final Logger log = LoggerFactory.getLogger(StochasticBankIT.class);
   private static AtomicInteger txCount = new AtomicInteger();
 
   @Test
@@ -88,7 +91,7 @@ public class StochasticBankIT extends ITBaseImpl {
       thread.join();
     }
 
-    System.out.println("txCount : " + txCount.get());
+    log.debug("txCount : " + txCount.get());
     Assert.assertTrue("txCount : " + txCount.get(), txCount.get() > 0);
 
     runVerifier(env, numAccounts, 1);
@@ -197,7 +200,7 @@ public class StochasticBankIT extends ITBaseImpl {
 
         long t2 = System.currentTimeMillis();
 
-        System.out.printf("avg : %,9.2f  min : %,6d  max : %,6d  stddev : %1.2f  rate : %,6.2f\n",
+        log.debug("avg : %,9.2f  min : %,6d  max : %,6d  stddev : %1.2f  rate : %,6.2f\n",
             stat.getAverage(), stat.getMin(), stat.getMax(), stat.getStdDev(), numAccounts
                 / ((t2 - t1) / 1000.0));
 
@@ -222,7 +225,7 @@ public class StochasticBankIT extends ITBaseImpl {
     Map<String, String> bals2 = toMap(tx);
 
     if (!bals1.keySet().equals(bals2.keySet())) {
-      System.out.print("KS NOT EQ");
+      log.debug("KS NOT EQ");
     }
 
     int sum1 = 0;
@@ -237,12 +240,12 @@ public class StochasticBankIT extends ITBaseImpl {
         sum1 += v1;
         sum2 += v2;
 
-        System.out.println(entry.getKey() + " " + entry.getValue() + " " + val2 + " " + (v2 - v1));
+        log.debug(entry.getKey() + " " + entry.getValue() + " " + val2 + " " + (v2 - v1));
       }
     }
 
-    System.out.println("start times : " + lastTx.getStartTs() + " " + tx.getStartTs());
-    System.out.printf("sum1 : %,d  sum2 : %,d  diff : %,d\n", sum1, sum2, sum2 - sum1);
+    log.debug("start times : " + lastTx.getStartTs() + " " + tx.getStartTs());
+    log.debug("sum1 : %,d  sum2 : %,d  diff : %,d\n", sum1, sum2, sum2 - sum1);
 
     File tmpFile = File.createTempFile("sb_dump", ".txt");
     Writer fw = new BufferedWriter(new FileWriter(tmpFile));
@@ -256,8 +259,7 @@ public class StochasticBankIT extends ITBaseImpl {
 
     fw.close();
 
-    System.out.println("Dumped table : " + tmpFile);
-
+    log.debug("Dumped table : " + tmpFile);
   }
 
   private static HashMap<String, String> toMap(TestTransaction tx) throws Exception {

--- a/modules/integration/src/test/resources/log4j.properties
+++ b/modules/integration/src/test/resources/log4j.properties
@@ -21,6 +21,7 @@ log4j.logger.org.apache.curator=ERROR
 log4j.logger.org.apache.accumulo.core.client.impl.ServerClient=ERROR
 log4j.logger.org.apache.accumulo.core.util.shell.Shell.audit=off
 log4j.logger.org.apache.accumulo.core.util.shell.Shell=FATAL
+log4j.logger.org.apache.accumulo.minicluster=ERROR
 log4j.logger.org.apache.commons.vfs2.impl.DefaultFileSystemManager=WARN
 log4j.logger.org.apache.hadoop.io.compress.CodecPool=WARN
 log4j.logger.org.apache.hadoop.metrics=WARN


### PR DESCRIPTION
* Converted calls to System.out.print* to log.debug
* Increased log level for minicluster
* Removed commented out System.out call