### PR TITLE
Avoid use of auxiliary class, and other warnings

### DIFF
--- a/modules/api/src/test/java/org/apache/fluo/api/data/AsciiSequence.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/AsciiSequence.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.fluo.api.data;
+
+import java.nio.charset.StandardCharsets;
+
+class AsciiSequence implements CharSequence {
+
+
+  private final int len;
+  private final int offset;
+  private final byte[] chars;
+
+  public AsciiSequence(byte[] chars, int offset, int len) {
+    this.len = len;
+    this.offset = offset;
+    this.chars = chars;
+  }
+
+  public AsciiSequence(String s) {
+    chars = s.getBytes(StandardCharsets.US_ASCII);
+    len = chars.length;
+    offset = 0;
+  }
+
+  @Override
+  public int length() {
+    return len;
+  }
+
+  @Override
+  public char charAt(int index) {
+    return (char) chars[index];
+  }
+
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return new AsciiSequence(chars, offset + start, end - start);
+  }
+
+}

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -26,43 +26,6 @@ import org.apache.fluo.api.data.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
-class AsciiSequence implements CharSequence {
-
-
-  private final int len;
-  private final int offset;
-  private final byte[] chars;
-
-  public AsciiSequence(byte[] chars, int offset, int len) {
-    this.len = len;
-    this.offset = offset;
-    this.chars = chars;
-  }
-
-  public AsciiSequence(String s) {
-    chars = s.getBytes(StandardCharsets.US_ASCII);
-    len = chars.length;
-    offset = 0;
-  }
-
-  @Override
-  public int length() {
-    return len;
-  }
-
-  @Override
-  public char charAt(int index) {
-    return (char) chars[index];
-  }
-
-  @Override
-  public CharSequence subSequence(int start, int end) {
-    return new AsciiSequence(chars, offset + start, end - start);
-  }
-
-}
-
-
 /**
  * Unit test for {@link Bytes}
  */

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TransactionImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TransactionImpl.java
@@ -229,7 +229,7 @@ public class TransactionImpl implements AsyncTransaction, Snapshot {
 
     SnapshotScanner.Opts opts;
     if (shouldCopy) {
-      HashSet<Column> cols = new HashSet<Column>();
+      HashSet<Column> cols = new HashSet<>();
       for (Column column : columns) {
         if (column.isVisibilitySet()) {
           cols.add(new Column(column.getFamily(), column.getQualifier()));

--- a/modules/core/src/main/java/org/apache/fluo/core/thrift/OracleService.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/thrift/OracleService.java
@@ -26,6 +26,7 @@ import org.apache.thrift.server.AbstractNonblockingServer.AsyncFrameBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings({"rawtypes", "unused", "serial", "unchecked"})
 public class OracleService {
 
   public interface Iface {

--- a/modules/core/src/main/java/org/apache/fluo/core/thrift/Stamps.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/thrift/Stamps.java
@@ -21,6 +21,7 @@ import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
 import org.apache.thrift.scheme.TupleScheme;
 
+@SuppressWarnings({"rawtypes", "unused", "serial", "unchecked"})
 public class Stamps implements org.apache.thrift.TBase<Stamps, Stamps._Fields>,
     java.io.Serializable, Cloneable, Comparable<Stamps> {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC =

--- a/modules/core/src/main/java/org/apache/fluo/core/worker/finder/hash/ScanTask.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/worker/finder/hash/ScanTask.java
@@ -57,13 +57,12 @@ public class ScanTask implements Runnable {
 
   ScanTask(HashNotificationFinder hashWorkFinder, Environment env, AtomicBoolean stopped) {
     this.hwf = hashWorkFinder;
-    this.tabletInfoCache =
-        new TabletInfoCache<TabletData, Supplier<TabletData>>(env, new Supplier<TabletData>() {
-          @Override
-          public TabletData get() {
-            return new TabletData();
-          }
-        });
+    this.tabletInfoCache = new TabletInfoCache<>(env, new Supplier<TabletData>() {
+      @Override
+      public TabletData get() {
+        return new TabletData();
+      }
+    });
     this.env = env;
     this.stopped = stopped;
 


### PR DESCRIPTION
* Move auxiliary AsciiSequence class to own file
* Remove redundant type args (use diamond)
* Suppress warnings in thrift classes