### PR TITLE
Fixes #788 - Add 'Apache' to Maven module names

### DIFF
--- a/modules/accumulo/pom.xml
+++ b/modules/accumulo/pom.xml
@@ -22,11 +22,11 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-accumulo</artifactId>
-  <name>Fluo Accumulo Extensions</name>
-  <description>This module contains all Fluo code that is run by Accumulo.  This includes iterators and formatters.
-    Given that this module produces a JAR that needs to be included on the Accumulo classpath, external
-    dependencies should be limited.  Some utility classes in this module are not only used by iterators
-    but also used by fluo-core.</description>
+  <name>Apache Fluo (incubating) Accumulo Extensions</name>
+  <description>This module contains all Apache Fluo code that is run by Accumulo. This includes
+    iterators and formatters. Given that this module produces a JAR that needs to be included on the
+    Accumulo classpath, external dependencies should be limited. Some utility classes in this module
+    are not only used by iterators but also used by fluo-core.</description>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/modules/api/pom.xml
+++ b/modules/api/pom.xml
@@ -22,10 +22,10 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-api</artifactId>
-  <name>Fluo API</name>
-  <description>This module contains all API code.  External dependencies should be limited.  Any changes to
-    public methods should be avoided.  While the API module does not have compile time dependency
-    on fluo-core, you must include fluo-core as a run-time dependency.</description>
+  <name>Apache Fluo (incubating) API</name>
+  <description>This module contains all API code for Apache Fluo. External dependencies should be
+    limited. Any changes to public methods should be avoided. While the API module does not have
+    compile time dependency on fluo-core, you must include fluo-core as a run-time dependency.</description>
   <!-- Avoid (if possible) adding new dependencies to the API jar -->
   <dependencies>
     <dependency>

--- a/modules/cluster/pom.xml
+++ b/modules/cluster/pom.xml
@@ -22,11 +22,11 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-cluster</artifactId>
-  <name>Fluo Cluster</name>
-  <description>This module contains all code necessary to run Fluo on a YARN cluster using Apache Twill.
-    It was separated from fluo-core to keep dependencies (like Twill) out of Fluo clients which
-    depend on the fluo-core jar.  It was also done to limit conflicts.  For example, Twill
-    requires logback to be used but fluo-core requires log4j (due to zookeeper requiring it in
+  <name>Apache Fluo (incubating) Cluster</name>
+  <description>This module contains all code necessary to run Apache Fluo on a YARN cluster using
+    Apache Twill. It was separated from fluo-core to keep dependencies (like Twill) out of Fluo
+    clients which depend on the fluo-core jar.  It was also done to limit conflicts. For example,
+    Twill requires logback to be used but fluo-core requires log4j (due to zookeeper requiring it in
     accumulo-minicluster).</description>
   <dependencies>
     <dependency>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -22,8 +22,8 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-core</artifactId>
-  <name>Fluo Core</name>
-  <description>The modules contains the core implementation code of Fluo.</description>
+  <name>Apache Fluo (incubating) Core</name>
+  <description>The modules contains the core implementation code of Apache Fluo.</description>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -23,9 +23,9 @@
   </parent>
   <artifactId>fluo</artifactId>
   <packaging>pom</packaging>
-  <name>Fluo Distribution</name>
-  <description>This module produces a tarball distribution of Fluo.  It contains all of the default configuration
-    and scripts required for the distribution.</description>
+  <name>Apache Fluo (incubating) Distribution</name>
+  <description>This module produces a tarball distribution of Apache Fluo. It contains all of the
+    default configuration and scripts required for the distribution.</description>
   <!-- NOTE: These dependencies are bundled in this assembly -->
   <dependencies>
     <dependency>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -22,8 +22,8 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-integration</artifactId>
-  <name>Fluo Integration</name>
-  <description>This module contains Fluo integration tests</description>
+  <name>Apache Fluo (incubating) Integration</name>
+  <description>This module contains Apache Fluo integration tests</description>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/modules/mapreduce/pom.xml
+++ b/modules/mapreduce/pom.xml
@@ -22,8 +22,9 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-mapreduce</artifactId>
-  <name>Fluo MapReduce</name>
-  <description>This module provides utility code for MapReduce jobs that read from or write to a Fluo table.</description>
+  <name>Apache Fluo (incubating) MapReduce Utilities</name>
+  <description>This module provides utility code for MapReduce jobs that read from or write to a
+    Apache Fluo table.</description>
   <dependencies>
     <dependency>
       <groupId>org.apache.accumulo</groupId>

--- a/modules/mini/pom.xml
+++ b/modules/mini/pom.xml
@@ -22,9 +22,9 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-mini</artifactId>
-  <name>Fluo Mini</name>
-  <description>This module contains the implementation code of MiniFluo.  It was separated from fluo-core
-    to remove the dependency on accumulo-minicluster from core.</description>
+  <name>Apache Fluo (incubating) Mini</name>
+  <description>This module contains the implementation code of MiniFluo. It was separated from
+    fluo-core to remove the dependency on accumulo-minicluster from core.</description>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>fluo-project</artifactId>
   <version>1.1.0-incubating-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Fluo Project</name>
+  <name>Apache Fluo (incubating) Project</name>
   <description>An implementation of Percolator for Apache Accumulo</description>
   <licenses>
     <license>


### PR DESCRIPTION
* Improved Apache branding in descriptions also