### PR TITLE
Added some caching of string to bytes conversions for #800

### DIFF
--- a/modules/api/src/main/java/org/apache/fluo/api/data/Column.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Column.java
@@ -33,6 +33,7 @@ public final class Column implements Comparable<Column>, Serializable {
   private Bytes family = UNSET;
   private Bytes qualifier = UNSET;
   private Bytes visibility = UNSET;
+  private int hashCode = 0;
 
   public static final Column EMPTY = new Column();
 
@@ -172,11 +173,20 @@ public final class Column implements Comparable<Column>, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(family, qualifier, visibility);
+    if (hashCode == 0) {
+      hashCode = Objects.hash(family, qualifier, visibility);
+    }
+
+    return hashCode;
   }
 
   @Override
   public int compareTo(Column other) {
+
+    if (this == other) {
+      return 0;
+    }
+
     int result = family.compareTo(other.family);
     if (result == 0) {
       result = qualifier.compareTo(other.qualifier);
@@ -189,8 +199,14 @@ public final class Column implements Comparable<Column>, Serializable {
 
   @Override
   public boolean equals(Object o) {
+
+    if (this == o) {
+      return true;
+    }
+
     if (o instanceof Column) {
       Column oc = (Column) o;
+
       return family.equals(oc.getFamily()) && qualifier.equals(oc.getQualifier())
           && visibility.equals(oc.getVisibility());
     }

--- a/modules/api/src/main/java/org/apache/fluo/api/data/ColumnValue.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/ColumnValue.java
@@ -27,6 +27,7 @@ public final class ColumnValue implements Serializable, Comparable<ColumnValue> 
 
   private Column column;
   private Bytes val;
+  private int hashCode = 0;
 
   public ColumnValue(Column col, Bytes val) {
     this.column = col;
@@ -55,6 +56,11 @@ public final class ColumnValue implements Serializable, Comparable<ColumnValue> 
 
   @Override
   public int compareTo(ColumnValue o) {
+
+    if (this == o) {
+      return 0;
+    }
+
     int comp = column.compareTo(o.column);
     if (comp == 0) {
       comp = val.compareTo(o.val);
@@ -64,6 +70,11 @@ public final class ColumnValue implements Serializable, Comparable<ColumnValue> 
 
   @Override
   public boolean equals(Object o) {
+
+    if (this == o) {
+      return true;
+    }
+
     if (o instanceof ColumnValue) {
       ColumnValue ocv = (ColumnValue) o;
       return column.equals(ocv.column) && val.equals(ocv.val);
@@ -74,7 +85,10 @@ public final class ColumnValue implements Serializable, Comparable<ColumnValue> 
 
   @Override
   public int hashCode() {
-    return Objects.hash(column, val);
+    if (hashCode == 0) {
+      hashCode = Objects.hash(column, val);
+    }
+    return hashCode;
   }
 
   @Override

--- a/modules/api/src/main/java/org/apache/fluo/api/data/RowColumn.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/RowColumn.java
@@ -31,6 +31,7 @@ public final class RowColumn implements Comparable<RowColumn>, Serializable {
 
   private Bytes row = Bytes.EMPTY;
   private Column col = Column.EMPTY;
+  private int hashCode = 0;
 
   /**
    * Constructs a RowColumn with row set to Bytes.EMPTY and column set to Column.EMPTY
@@ -113,6 +114,11 @@ public final class RowColumn implements Comparable<RowColumn>, Serializable {
 
   @Override
   public boolean equals(Object o) {
+
+    if (this == o) {
+      return true;
+    }
+
     if (o instanceof RowColumn) {
       RowColumn other = (RowColumn) o;
       return row.equals(other.row) && col.equals(other.col);
@@ -122,7 +128,11 @@ public final class RowColumn implements Comparable<RowColumn>, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(row, col);
+    if (hashCode == 0) {
+      hashCode = Objects.hash(row, col);
+    }
+
+    return hashCode;
   }
 
   /**
@@ -158,6 +168,11 @@ public final class RowColumn implements Comparable<RowColumn>, Serializable {
 
   @Override
   public int compareTo(RowColumn other) {
+
+    if (this == other) {
+      return 0;
+    }
+
     int result = row.compareTo(other.row);
     if (result == 0) {
       result = col.compareTo(other.col);

--- a/modules/api/src/main/java/org/apache/fluo/api/data/RowColumnValue.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/RowColumnValue.java
@@ -29,6 +29,7 @@ public final class RowColumnValue implements Comparable<RowColumnValue>, Seriali
   private Bytes row = Bytes.EMPTY;
   private Column col = Column.EMPTY;
   private Bytes val = Bytes.EMPTY;
+  private int hashCode = 0;
 
   public RowColumnValue(Bytes row, Column col, Bytes val) {
     this.row = row;
@@ -87,11 +88,15 @@ public final class RowColumnValue implements Comparable<RowColumnValue>, Seriali
 
   @Override
   public int hashCode() {
-    return Objects.hash(row, col, val);
+    if (hashCode == 0) {
+      hashCode = Objects.hash(row, col, val);
+    }
+    return hashCode;
   }
 
   @Override
   public boolean equals(Object o) {
+
     if (o == this) {
       return true;
     }
@@ -110,6 +115,11 @@ public final class RowColumnValue implements Comparable<RowColumnValue>, Seriali
 
   @Override
   public int compareTo(RowColumnValue o) {
+
+    if (this == o) {
+      return 0;
+    }
+
     int result = row.compareTo(o.row);
     if (result == 0) {
       result = col.compareTo(o.col);

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -211,4 +211,16 @@ public class BytesTest {
     AsciiSequence cs2 = new AsciiSequence("");
     Assert.assertSame(Bytes.EMPTY, Bytes.of(cs2));
   }
+
+  @Test
+  public void testSameString() {
+    String s1 = "abc";
+    String s2 = "xyZ";
+
+    Bytes b1 = Bytes.of(s1);
+    Bytes b2 = Bytes.of(s2);
+
+    Assert.assertSame(s1, b1.toString());
+    Assert.assertSame(s2, b2.toString());
+  }
 }

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/Notification.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/Notification.java
@@ -43,6 +43,7 @@ public class Notification {
 
   private final RowColumn rowCol;
   private final long timestamp;
+  private static final byte[] NOTIFY_CF_ARRAY = ColumnConstants.NOTIFY_CF.toArray();
 
   public Notification(Bytes row, Column col, long ts) {
     rowCol = new RowColumn(row, col);
@@ -72,15 +73,14 @@ public class Notification {
   public Flutation newDelete(Environment env, long ts) {
     Flutation m = new Flutation(env, rowCol.getRow());
     ColumnVisibility cv = env.getSharedResources().getVisCache().getCV(rowCol.getColumn());
-    m.put(ColumnConstants.NOTIFY_CF.toArray(), encodeCol(rowCol.getColumn()), cv,
-        encodeTs(ts, true), TransactionImpl.EMPTY);
+    m.put(NOTIFY_CF_ARRAY, encodeCol(rowCol.getColumn()), cv, encodeTs(ts, true),
+        TransactionImpl.EMPTY);
     return m;
   }
 
   public static void put(Environment env, Mutation m, Column col, long ts) {
     ColumnVisibility cv = env.getSharedResources().getVisCache().getCV(col);
-    m.put(ColumnConstants.NOTIFY_CF.toArray(), encodeCol(col), cv, encodeTs(ts, false),
-        TransactionImpl.EMPTY);
+    m.put(NOTIFY_CF_ARRAY, encodeCol(col), cv, encodeTs(ts, false), TransactionImpl.EMPTY);
   }
 
   public static Notification from(Key k) {

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/ScannerBuilderImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/ScannerBuilderImpl.java
@@ -74,7 +74,7 @@ public class ScannerBuilderImpl implements ScannerBuilder {
   @Override
   public CellScanner build() {
     SnapshotScanner snapScanner = tx.newSnapshotScanner(span, columns);
-    return new CellScannerImpl(snapScanner);
+    return new CellScannerImpl(snapScanner, columns);
   }
 
   @Override
@@ -83,7 +83,7 @@ public class ScannerBuilderImpl implements ScannerBuilder {
       @Override
       public RowScanner build() {
         SnapshotScanner snapScanner = tx.newSnapshotScanner(span, columns);
-        return new RowScannerImpl(snapScanner);
+        return new RowScannerImpl(snapScanner, columns);
       }
     };
   }

--- a/modules/core/src/main/java/org/apache/fluo/core/util/ByteUtil.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/util/ByteUtil.java
@@ -57,6 +57,10 @@ public class ByteUtil {
    * @return Bytes object
    */
   public static Bytes toBytes(ByteSequence bs) {
+    if (bs.length() == 0) {
+      return Bytes.EMPTY;
+    }
+
     if (bs.isBackedByArray()) {
       return Bytes.of(bs.getBackingArray(), bs.offset(), bs.length());
     } else {

--- a/modules/core/src/main/java/org/apache/fluo/core/util/CachedColumnConverter.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/util/CachedColumnConverter.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.fluo.core.util;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.fluo.api.data.Bytes;
+import org.apache.fluo.api.data.Column;
+
+public class CachedColumnConverter implements Function<Key, Column> {
+  private Map<ColumnKey, Column> colCache = new HashMap<>();
+  private ColumnKey resuableKey = new ColumnKey();
+
+  private static class ColumnKey {
+    private ByteSequence family;
+    private ByteSequence qualifier;
+    private ByteSequence vis;
+    private int hashCode = 0;
+
+    ColumnKey() {}
+
+    ColumnKey(Column col) {
+      this.family = ByteUtil.toByteSequence(col.getFamily());
+      this.qualifier = ByteUtil.toByteSequence(col.getQualifier());
+      this.vis = ByteUtil.toByteSequence(col.getVisibility());
+      this.hashCode = 0;
+    }
+
+    void reset(ByteSequence family, ByteSequence qualifier, ByteSequence vis) {
+      this.family = family;
+      this.qualifier = qualifier;
+      this.vis = vis;
+      this.hashCode = 0;
+    }
+
+    @Override
+    public int hashCode() {
+      if (hashCode == 0) {
+        hashCode = family.hashCode();
+        hashCode = 31 * hashCode + qualifier.hashCode();
+        hashCode = 31 * hashCode + vis.hashCode();
+      }
+
+      return hashCode;
+    }
+
+    public boolean equals(Object o) {
+      if (o instanceof ColumnKey) {
+        ColumnKey ock = (ColumnKey) o;
+        return family.equals(ock.family) && qualifier.equals(ock.qualifier) && vis.equals(ock.vis);
+      }
+
+      return false;
+    }
+  }
+
+  public CachedColumnConverter(Collection<Column> cols) {
+    for (Column col : cols) {
+      colCache.put(new ColumnKey(col), col);
+    }
+  }
+
+  @Override
+  public Column apply(Key k) {
+    return toColumn(k.getColumnFamilyData(), k.getColumnQualifierData(),
+        k.getColumnVisibilityData());
+  }
+
+  private Column toColumn(ByteSequence family, ByteSequence qualifier, ByteSequence vis) {
+    resuableKey.reset(family, qualifier, vis);
+    Column col = colCache.get(resuableKey);
+
+    if (col == null) {
+      Bytes f = ByteUtil.toBytes(family);
+      Bytes q = ByteUtil.toBytes(qualifier);
+      Bytes v = ByteUtil.toBytes(vis);
+      return new Column(f, q, v);
+    }
+
+    return col;
+  }
+}

--- a/modules/core/src/main/java/org/apache/fluo/core/util/ColumnUtil.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/util/ColumnUtil.java
@@ -115,4 +115,11 @@ public class ColumnUtil {
     Bytes visibility = ByteUtil.read(bb, in);
     return new Column(family, qualifier, visibility);
   }
+
+  public static Column convert(Key k) {
+    Bytes f = ByteUtil.toBytes(k.getColumnFamilyData());
+    Bytes q = ByteUtil.toBytes(k.getColumnQualifierData());
+    Bytes v = ByteUtil.toBytes(k.getColumnVisibilityData());
+    return new Column(f, q, v);
+  }
 }

--- a/modules/core/src/main/java/org/apache/fluo/core/util/Flutation.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/util/Flutation.java
@@ -16,7 +16,6 @@
 package org.apache.fluo.core.util;
 
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
@@ -50,7 +49,6 @@ public class Flutation extends Mutation {
       cv = new ColumnVisibility(ByteUtil.toText(col.getVisibility()));
     }
 
-    m.put(ByteUtil.toText(col.getFamily()), ByteUtil.toText(col.getQualifier()), cv, ts, new Value(
-        val));
+    m.put(col.getFamily().toArray(), col.getQualifier().toArray(), cv, ts, val);
   }
 }


### PR DESCRIPTION
 * Added some localized per transactions caching of string to bytes conversions
 * Optimized hashCode(), equals(), and compareTo() methods for data objects in API
 * Made transaction reuse passed in Bytes and Column objects when returning data
 * Optimized Bytes.toString() by weakly remembering the string that created it.