### PR TITLE
closes #827 - implement a copyTo

### DIFF
--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -574,13 +574,11 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * @param destPos starting position in the destination data.
    * @exception IndexOutOfBoundsException if copying would cause access of data outside array
    *            bounds.
-   * @exception ArrayStoreException if an element in the <code>src</code> array could not be stored
-   *            into the <code>dest</code> array because of a type mismatch.
    * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
    *            <code>null</code>.
    */
-  public void copyTo(Object dest, int destPos) {
-    arraycopy(this, 0, dest, destPos, this.length);
+  public void copyTo(byte[] dest, int destPos) {
+    arraycopy(0, dest, destPos, this.length);
   }
 
   /**
@@ -593,37 +591,17 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * @param destPos starting position in the destination data.
    * @exception IndexOutOfBoundsException if copying would cause access of data outside array
    *            bounds.
-   * @exception ArrayStoreException if an element in the <code>src</code> array could not be stored
-   *            into the <code>dest</code> array because of a type mismatch.
    * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
    *            <code>null</code>.
    */
-  public void copyTo(int start, int end, Object dest, int destPos) {
-    // Using this.subSequence(start, end).copyTo(dest, destPos)
-    // would allocate another Bytes object
-    arraycopy(this, start, dest, destPos, end - start);
+  public void copyTo(int start, int end, byte[] dest, int destPos) {
+    // this.subSequence(start, end).copyTo(dest, destPos) would allocate another Bytes object
+    arraycopy(start, dest, destPos, end - start);
   }
 
-  /**
-   * Copies an array from the specified source Bytes, beginning at the specified position, to the
-   * specified position of the destination array starting at the destPos offset. Copies the length
-   * specified to the dest array. Uses {@link java.lang.System#arraycopy} under the covers, so the
-   * same exceptions can be thrown
-   * 
-   * @param src Bytes object that will converted to byte[]
-   * @param start starting position in the source array.
-   * @param dest the destination array.
-   * @param destPos starting position in the destination data.
-   * @param length the number of array elements to be copied.
-   * @exception IndexOutOfBoundsException if copying would cause access of data outside array
-   *            bounds.
-   * @exception ArrayStoreException if an element in the <code>src</code> array could not be stored
-   *            into the <code>dest</code> array because of a type mismatch.
-   * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
-   *            <code>null</code>.
-   */
-  public static void arraycopy(Bytes src, int start, Object dest, int destPos, int length) {
-    System.arraycopy(src.toArray(), start, dest, destPos, length);
+  private void arraycopy(int start, byte[] dest, int destPos, int length) {
+    // since dest is byte[], we can't get the ArrayStoreException
+    System.arraycopy(this.data, start + this.offset, dest, destPos, length);
   }
 
 }

--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -565,4 +565,72 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
   public static BytesBuilder builder(int initialCapacity) {
     return new BytesBuilder(initialCapacity);
   }
+
+  /**
+   * Copy entire Bytes object to specific byte array
+   * <p>
+   * Uses the specified offset in the dest byte array to start the copy.
+   * 
+   * @see Bytes.arraycopy
+   * 
+   * @param dest destination array
+   * @param destPos starting position in the destination data.
+   * @exception IndexOutOfBoundsException if copying would cause access of data outside array
+   *            bounds.
+   * @exception ArrayStoreException if an element in the <code>src</code> array could not be stored
+   *            into the <code>dest</code> array because of a type mismatch.
+   * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
+   *            <code>null</code>.
+   */
+  public void copyTo(Object dest, int destPos) {
+    arraycopy(this, 0, dest, destPos, this.length);
+  }
+
+  /**
+   * Copy a subsequence of Bytes to specific byte array
+   * <p>
+   * Uses the specified offset in the dest byte array to start the copy.
+   * 
+   * @see Bytes.arraycopy
+   * 
+   * @param start index of subsequence start (inclusive)
+   * @param end index of subsequence end (exclusive)
+   * @param dest destination array
+   * @param destPos starting position in the destination data.
+   * @exception IndexOutOfBoundsException if copying would cause access of data outside array
+   *            bounds.
+   * @exception ArrayStoreException if an element in the <code>src</code> array could not be stored
+   *            into the <code>dest</code> array because of a type mismatch.
+   * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
+   *            <code>null</code>.
+   */
+  public void copyTo(int start, int end, Object dest, int destPos) {
+    // Using this.subSequence(start, end).copyTo(dest, destPos)
+    // would allocate another Bytes object
+    arraycopy(this, start, dest, destPos, end - start);
+  }
+
+  /**
+   * Copies an array from the specified source Bytes, beginning at the specified position, to the
+   * specified position of the destination array starting at the destPos offset. Copies the length
+   * specified to the dest array.
+   * <p>
+   * Uses {@link java.lang.System#arraycopy} under the covers, so the same exceptions can be thrown
+   * 
+   * @param src Bytes object that will converted to byte[]
+   * @param srcPos starting position in the source array.
+   * @param dest the destination array.
+   * @param destPos starting position in the destination data.
+   * @param length the number of array elements to be copied.
+   * @exception IndexOutOfBoundsException if copying would cause access of data outside array
+   *            bounds.
+   * @exception ArrayStoreException if an element in the <code>src</code> array could not be stored
+   *            into the <code>dest</code> array because of a type mismatch.
+   * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
+   *            <code>null</code>.
+   */
+  public static void arraycopy(Bytes src, int start, Object dest, int destPos, int length) {
+    System.arraycopy(src.toArray(), start, dest, destPos, length);
+  }
+
 }

--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -568,7 +568,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
 
   /**
    * Copy entire Bytes object to specific byte array. Uses the specified offset in the dest byte
-   * array to start the copy. See {@link org.apache.fluo.api.data.Bytes#arraycopy}.
+   * array to start the copy.
    * 
    * @param dest destination array
    * @param destPos starting position in the destination data.
@@ -576,6 +576,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    *            bounds.
    * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
    *            <code>null</code>.
+   * @since 1.1.0
    */
   public void copyTo(byte[] dest, int destPos) {
     arraycopy(0, dest, destPos, this.length);
@@ -583,7 +584,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
 
   /**
    * Copy a subsequence of Bytes to specific byte array. Uses the specified offset in the dest byte
-   * array to start the copy. See {@link org.apache.fluo.api.data.Bytes#arraycopy}.
+   * array to start the copy.
    * 
    * @param start index of subsequence start (inclusive)
    * @param end index of subsequence end (exclusive)
@@ -593,6 +594,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    *            bounds.
    * @exception NullPointerException if either <code>src</code> or <code>dest</code> is
    *            <code>null</code>.
+   * @since 1.1.0
    */
   public void copyTo(int start, int end, byte[] dest, int destPos) {
     // this.subSequence(start, end).copyTo(dest, destPos) would allocate another Bytes object

--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -567,11 +567,8 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
   }
 
   /**
-   * Copy entire Bytes object to specific byte array
-   * <p>
-   * Uses the specified offset in the dest byte array to start the copy.
-   * 
-   * @see Bytes.arraycopy
+   * Copy entire Bytes object to specific byte array. Uses the specified offset in the dest byte
+   * array to start the copy. See {@link org.apache.fluo.api.data.Bytes#arraycopy}.
    * 
    * @param dest destination array
    * @param destPos starting position in the destination data.
@@ -587,11 +584,8 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
   }
 
   /**
-   * Copy a subsequence of Bytes to specific byte array
-   * <p>
-   * Uses the specified offset in the dest byte array to start the copy.
-   * 
-   * @see Bytes.arraycopy
+   * Copy a subsequence of Bytes to specific byte array. Uses the specified offset in the dest byte
+   * array to start the copy. See {@link org.apache.fluo.api.data.Bytes#arraycopy}.
    * 
    * @param start index of subsequence start (inclusive)
    * @param end index of subsequence end (exclusive)
@@ -613,12 +607,11 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
   /**
    * Copies an array from the specified source Bytes, beginning at the specified position, to the
    * specified position of the destination array starting at the destPos offset. Copies the length
-   * specified to the dest array.
-   * <p>
-   * Uses {@link java.lang.System#arraycopy} under the covers, so the same exceptions can be thrown
+   * specified to the dest array. Uses {@link java.lang.System#arraycopy} under the covers, so the
+   * same exceptions can be thrown
    * 
    * @param src Bytes object that will converted to byte[]
-   * @param srcPos starting position in the source array.
+   * @param start starting position in the source array.
    * @param dest the destination array.
    * @param destPos starting position in the destination data.
    * @param length the number of array elements to be copied.

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -24,7 +24,6 @@ import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import org.apache.fluo.api.data.Bytes.BytesBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -319,14 +318,12 @@ public class BytesTest {
     Assert.assertEquals("c†𝔊e", new String(copyTo));
 
     // now make a Bytes out of the craziness
-    BytesBuilder builder = new BytesBuilder(15);
-    builder.append(new String(copyFrom));
-    Bytes all = builder.toBytes();
-    Assert.assertEquals(15, all.length());
+    Bytes allBytes = Bytes.of(copyFrom);
+    Assert.assertEquals(15, allBytes.length());
 
     // and test Bytes.arraycopy works the same
     byte[] copyTo2 = new byte[9];
-    Bytes.arraycopy(all, 2, copyTo2, 0, 9);
+    Bytes.arraycopy(allBytes, 2, copyTo2, 0, 9);
     Assert.assertEquals("c†𝔊e", new String(copyTo2));
   }
 

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -300,7 +300,7 @@ public class BytesTest {
   }
 
   @Test
-  public void testArraycopyWithUnicode() {
+  public void testCopyToWithUnicode() {
     // first observe System.arraycopy
     String begin = "abc"; // 3 chars, 3 bytes
     String mid1 = "†"; // 1 char, 3 bytes
@@ -309,8 +309,10 @@ public class BytesTest {
     Assert.assertEquals(11, begin.length() + mid1.length() + mid2.length() + end.length());
 
     byte[] copyFrom = (begin + mid1 + mid2 + end).getBytes();
-    // [ a, b, c, †, 𝔊, e, f, g, h, i]
+    //@formatter:off
+    // [ a,  b,  c,              †,                    𝔊,   e,   f,   g,   h,   i]
     // [97, 98, 99, -30, -128, -96, -16, -99, -108, -118, 101, 102, 103, 104, 105]
+    //@formatter:on
     Assert.assertEquals(15, copyFrom.length);
 
     byte[] copyTo = new byte[9];
@@ -323,7 +325,7 @@ public class BytesTest {
 
     // and test Bytes.arraycopy works the same
     byte[] copyTo2 = new byte[9];
-    Bytes.arraycopy(allBytes, 2, copyTo2, 0, 9);
+    allBytes.copyTo(2, 11, copyTo2, 0);
     Assert.assertEquals("c†𝔊e", new String(copyTo2));
   }
 

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -300,6 +300,29 @@ public class BytesTest {
   }
 
   @Test
+  public void testCopyToArgsReversed() {
+    Bytes field = Bytes.of("abcdefg");
+    byte[] dest = new byte[4];
+
+    try {
+      field.copyTo(6, 3, dest, 0);
+      fail("should not get here");
+    } catch (java.lang.ArrayIndexOutOfBoundsException e) {
+      Assert.assertEquals("\0\0\0\0", new String(dest));
+    }
+  }
+
+  @Test
+  public void testCopyToNothing() {
+    Bytes field = Bytes.of("abcdefg");
+    byte[] dest = new byte[4];
+
+    field.copyTo(3, 3, dest, 0);
+    // should not have changed
+    Assert.assertEquals("\0\0\0\0", new String(dest));
+  }
+
+  @Test
   public void testCopyToWithUnicode() {
     // first observe System.arraycopy
     String begin = "abc"; // 3 chars, 3 bytes


### PR DESCRIPTION
that uses a new Bytes.arraycopy method.  That last test in BytesTests may a
little much, but I had to prove to myself how System.arraycopy was working.